### PR TITLE
[AMORO-3344] Fix the misdirection to quick start page when jumping from a three-level directory

### DIFF
--- a/amoro-docs/hugo.toml
+++ b/amoro-docs/hugo.toml
@@ -24,7 +24,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
 [menu]
 
   topnav = [
-    { name = "Quickstart", url = "../../quick-start/", weight = 100 },
+    { name = "Quickstart", pre = "relative", url = "../../quick-start/", weight = 100 },
     { name = "Docs", weight = 200 },
     { name = "latest", parent = "Docs", pre = "relative", url = "../../docs/latest/", weight = 201 },
     { name = "0.7.1-incubating", parent = "Docs", pre = "relative", url = "../../docs/0.7.1/", weight = 202 },


### PR DESCRIPTION
Apache/amoro#3344
Here, we set the “pre” attribute of the “Quickstart” navigation item to “relative”, so that every time we click on the Quickstart will start from the $.Site.BaseURL, i.e. $AMORO_HOMEPAGE/docs/$version. Therefore, the jump ../../quick-start/ will point to a fixed path: $AMORO_HOMEPAGE/quick-start, so that it is no longer affected by the user's current path (e.g. third-level directory).

I've tested it locally and it works.