### PR TITLE
[AMORO-3375] Fix error link for [Docs/latest] in the docs/0.6.1 page

### DIFF
--- a/amoro-site/hugo.toml
+++ b/amoro-site/hugo.toml
@@ -63,7 +63,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
     { name = "Setup", parent = "Quickstart", url = "/quickstart-setup/", weight = 101 },
     { name = "Quick Demo", parent = "Quickstart", url = "/quick-demo/", weight = 102 },
     { name = "Docs", weight = 200 },
-    { name = "latest", parent = "Docs", url = "/docs/lastest/", weight = 201 },
+    { name = "latest", parent = "Docs", url = "/docs/latest/", weight = 201 },
     { name = "0.6.1", parent = "Docs", url = "/docs/0.6.1/", weight = 202 },
     { name = "Benchmark", weight = 300 },
     { name = "Benchmark Report", parent = "Benchmark", url = "/benchmark-report/", weight = 301 },


### PR DESCRIPTION
## Why are the changes needed?
close：[#3375](https://github.com/apache/amoro/issues/3375)
